### PR TITLE
Upgrade io.methvin/directory-watcher 0.15.0 → 0.16.1

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,3 +1,3 @@
-{:deps {io.methvin/directory-watcher {:mvn/version "0.15.0"}}
+{:deps {io.methvin/directory-watcher {:mvn/version "0.16.1"}}
  :aliases {:release {:extra-deps {applied-science/deps-library {:mvn/version "0.4.0"}}
                      :main-opts ["-m" "applied-science.deps-library"]}}}


### PR DESCRIPTION
This upgrades the transitive dependency on the jna library from the version 5.7.0 to 5.12.1 which has a number of M1 arch related fixes. This seems to make the following crashes to go away on Mac M1 with macOS 12.6 Monterey:  

```
java.lang.UnsatisfiedLinkError: /private/.../jna7861170781989410123.tmp: dlopen(/private/.../jna7861170781989410123.tmp, 0x0001): tried: '/private/.../jna7861170781989410123.tmp' (fat file, but missing compatible architecture (have (unknown,i386,x86_64), need (arm64e)))
 at java.lang.ClassLoader$NativeLibrary.load (ClassLoader.java:-2)
    java.lang.ClassLoader.loadLibrary0 (ClassLoader.java:1950)
    java.lang.ClassLoader.loadLibrary (ClassLoader.java:1832)
    java.lang.Runtime.load0 (Runtime.java:811)
    java.lang.System.load (System.java:1088)
    com.sun.jna.Native.loadNativeLibraryFromJar (Native.java:744)
    com.sun.jna.Native.loadNativeLibrary (Native.java:678)
    com.sun.jna.Native.<clinit> (Native.java:106)
    io.methvin.watchservice.jna.CarbonAPI.<clinit> (CarbonAPI.java:20)
    io.methvin.watchservice.jna.CFStringRef.toCFString (CFStringRef.java:23)
    io.methvin.watchservice.MacOSXListeningWatchService.register (MacOSXListeningWatchService.java:127)
    io.methvin.watchservice.WatchablePath.register (WatchablePath.java:50)
    io.methvin.watcher.DirectoryWatcher.register (DirectoryWatcher.java:400)
    io.methvin.watcher.DirectoryWatcher.registerAll (DirectoryWatcher.java:373)
    io.methvin.watcher.DirectoryWatcher.<init> (DirectoryWatcher.java:193)
    io.methvin.watcher.DirectoryWatcher$Builder.build (DirectoryWatcher.java:122)
    nextjournal.beholder$create.invokeStatic (beholder.clj:29)
    nextjournal.beholder$create.invoke (beholder.clj:20)
    nextjournal.beholder$watch.invokeStatic (beholder.clj:37)
    nextjournal.beholder$watch.doInvoke (beholder.clj:31)
```