### PR TITLE
Upgrade directory-watcher with deleted events fix

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,3 +1,3 @@
-{:deps {io.methvin/directory-watcher {:mvn/version "0.15.0"}}
+{:deps {io.methvin/directory-watcher {:mvn/version "0.17.1"}}
  :aliases {:release {:extra-deps {applied-science/deps-library {:mvn/version "0.4.0"}}
                      :main-opts ["-m" "applied-science.deps-library"]}}}


### PR DESCRIPTION
Details in: https://github.com/gmethvin/directory-watcher/issues/55

Upgrading the upstream library to 0.17.1 fixes the issue I detected in #5. I have demonstrated the issue in this code: https://github.com/simongray/beholder-deletion-issue

The maintainer of directory-watcher was nice to fix the code on their end and publish this as 0.17.1.